### PR TITLE
Support Broccoli 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - 0.10
+  - "lts/*"
+  - "node"
 notifications:
   webhooks:
     urls:

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var browserify = require('browserify');
 var Plugin = require('broccoli-plugin');
 var md5Hex = require('md5hex');
 var TreeSync = require('tree-sync');
+var findUp = require('find-up');
 
 var statsForPaths = require('./lib/stats-for-paths');
 var updateCacheFromStats = require('./lib/update-cache-from-stats');
@@ -81,9 +82,24 @@ Watchify.prototype.build = function () {
   var outputDir = path.dirname(this.options.outputFile);
   var outputFile = destDir + '/' + this.options.outputFile;
 
+  var browserifyPaths = [];
+
+  var nodeModulesDir = findUp.sync('node_modules', {
+    cwd: path.resolve(process.cwd(), srcDir)
+  });
+
+  while (nodeModulesDir) {
+    browserifyPaths.push(nodeModulesDir);
+
+    nodeModulesDir = findUp.sync('node_modules', {
+      cwd: path.resolve(nodeModulesDir, '../..')
+    });
+  }
+
   mkdirp.sync(this.outputPath + '/' + path.dirname(outputDir));
 
   this.options.browserify.basedir = this.cachePath;
+  this.options.browserify.paths = browserifyPaths;
 
   var browserifyOptions = assignIn(this.options.browserify, this.watchifyData);
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "broccoli-plugin": "^1.2.1",
     "browserify": "^13.1.0",
+    "find-up": "^2.1.0",
     "fs-extra": "^1.0.0",
     "lodash.assignin": "^4.2.0",
     "md5hex": "^1.0.0",
@@ -41,7 +42,7 @@
     "xtend": "^4.0.1"
   },
   "devDependencies": {
-    "broccoli-builder": "^0.18.0",
+    "broccoli": "^1.1.3",
     "chai": "^3.5.0",
     "chai-files": "^1.4.0",
     "fixturify": "^0.3.0",

--- a/test/watchify-test.js
+++ b/test/watchify-test.js
@@ -1,7 +1,7 @@
 var chai = require('chai');
 var chaiFiles = require('chai-files');
 var fixturify = require('fixturify');
-var builder = require('broccoli-builder');
+var Builder = require('broccoli').Builder;
 var path = require('path');
 var fs = require('fs-extra');
 var expect = chai.expect;
@@ -35,7 +35,7 @@ describe('broccoli-watchify', function() {
 
   it('supports output path with directory', function() {
     fixturify.writeSync(INPUT_PATH, {
-      'index.js': "__invoke(require('./a'))",
+      'index.js': "__invoke(require('./a')); require('chai')",
       'a.js' : "module.exports = 1;"
     });
 
@@ -43,26 +43,26 @@ describe('broccoli-watchify', function() {
       outputFile: 'bundled/app.js'
     });
 
-    pipeline = new builder.Builder(node);
+    pipeline = new Builder(node);
 
-    return pipeline.build().then(function(results) {
-      fs.statSync(results.directory + '/bundled/app.js');
+    return pipeline.build().then(function() {
+      fs.statSync(pipeline.outputPath + '/bundled/app.js');
     });
   });
 
   it('has stable output', function() {
     fixturify.writeSync(INPUT_PATH, {
-      'index.js': "__invoke(require('./a'))",
+      'index.js': "__invoke(require('./a')); require('chai')",
       'a.js' : "module.exports = 1;"
     });
 
     var node = new Watchify(INPUT_PATH);
 
-    pipeline = new builder.Builder(node);
+    pipeline = new Builder(node);
 
     var first;
-    return pipeline.build().then(function(results) {
-      first = fs.statSync(results.directory + '/browserify.js');
+    return pipeline.build().then(function() {
+      first = fs.statSync(pipeline.outputPath + '/browserify.js');
       return new RSVP.Promise(function(resolve){
         // just make sure system with low mtime resolutions are considered,
         // Most legitimate changes include both mtime/size changes, or one of
@@ -73,23 +73,23 @@ describe('broccoli-watchify', function() {
         return pipeline.build();
       });
     }).then(function(results) {
-      var second = fs.statSync(results.directory + '/browserify.js');
+      var second = fs.statSync(pipeline.outputPath + '/browserify.js');
       expect(first).to.eql(second);
     });
   });
 
   it('defaults work', function() {
     fixturify.writeSync(INPUT_PATH, {
-      'index.js': "__invoke(require('./a'))",
+      'index.js': "__invoke(require('./a')); require('chai')",
       'a.js' : "module.exports = 1;"
     });
 
     var node = new Watchify(INPUT_PATH);
 
-    pipeline = new builder.Builder(node);
+    pipeline = new Builder(node);
 
-    return pipeline.build().then(function(results) {
-      var outputFile = results.directory + '/browserify.js';
+    return pipeline.build().then(function() {
+      var outputFile = pipeline.outputPath + '/browserify.js';
 
       expect(file(outputFile)).to.exist; // jshint ignore:line
 
@@ -104,7 +104,7 @@ describe('broccoli-watchify', function() {
 
       return pipeline.build();
     }).then(function(results) {
-      var outputFile = results.directory + '/browserify.js';
+      var outputFile = pipeline.outputPath + '/browserify.js';
 
       expect(file(outputFile)).to.exist; // jshint ignore:line
 
@@ -135,4 +135,3 @@ describe('broccoli-watchify', function() {
     };
   }
 });
-


### PR DESCRIPTION
Since Broccoli 1.x places tmp files in the OS's global tmp directory instead of `<project-root>/tmp`, we need to feed `<project-root>/node_modules` to Browserify through the `paths` option.

I have tested this solution, and it works as expected, the only thing I'm not sure of is whether we can rely on `process.cwd()` always pointing to the current Brocfile's directory. I assume this isn't something that will change upstream without notice, but it would of course be preferable to not rely on a hack.

Fixes #7